### PR TITLE
fix: use constant instead of simple expression

### DIFF
--- a/src/main/resources/camel-project-template/src/main/resources/spring/camel-context.xml
+++ b/src/main/resources/camel-project-template/src/main/resources/spring/camel-context.xml
@@ -28,7 +28,7 @@
                         <constant>application/vnd.oai.openapi+json</constant>
                     </setHeader>
                     <setBody id="setBody-for-openapi-document">
-                        <simple>resource:classpath:openapi.json</simple>
+                        <constant>resource:classpath:openapi.json</constant>
                     </setBody>
                 </route>
             </get>


### PR DESCRIPTION
By using simple expression the resource `resource:classpath:openapi.json` is loaded and then reinterpreted by the simple language expression support. This will lead to any escape newline characters within quoted strings to be expanded into newline characters breaking the string over multiple lines and in the end making the resulting resource served from `/openapi.json` an invalid JSON.

This is especially sensitive to `example` property within a `definitions` entry which are provided by end users when designing the API in Apicurio editor.