### PR TITLE
fix: health actuator endpoint

### DIFF
--- a/src/main/resources/camel-project-template/src/main/resources/application.yml
+++ b/src/main/resources/camel-project-template/src/main/resources/application.yml
@@ -9,10 +9,12 @@ camel:
 
 # Binding health checks to a different port
 management:
-  port: 8081
+  server:
+    port: 8081
 
-# disable all management enpoints except health
-endpoints:
-  enabled: false
-  health:
-    enabled: true
+  # disable all management enpoints except health
+  endpoints:
+    enabled-by-default: false
+  endpoint:
+    health:
+      enabled: true


### PR DESCRIPTION
Updates the configuration to match Spring Boot 2.3 actuator
configuration per[1]

Ref. https://issues.redhat.com/browse/ENTESB-17144

[1] https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.0-Migration-Guide#configuration-keys-structure