### PR TITLE
fix: health actuator endpoint (addenum)

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,10 +26,11 @@ server:
     workerThreads: 10
 
 management:
-  port: 8181
-  undertow:
-    ioThreads: 1
-    workerThreads: 1
+  server:
+    port: 8181
+    undertow:
+      ioThreads: 1
+      workerThreads: 1
 
 cors:
   allowedOrigins: "*"


### PR DESCRIPTION
Updates the configuration to match Spring Boot 2.3 actuator
configuration per[1] for the generator itself as well.

Ref. https://issues.redhat.com/browse/ENTESB-17144

[1] https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.0-Migration-Guide#configuration-keys-structure